### PR TITLE
Do not add CONTAINS edges + scalafmt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild/organization := "io.joern"
 ThisBuild/scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 
-val cpgVersion = "1.3.346"
+val cpgVersion = "1.3.348"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/ghidra2cpg-tests/src/test/scala/io/joern/ghidra2cpg/querying/x86/CallNodeTests.scala
+++ b/ghidra2cpg-tests/src/test/scala/io/joern/ghidra2cpg/querying/x86/CallNodeTests.scala
@@ -35,8 +35,9 @@ class CallNodeTests extends GhidraBinToCpgSuite {
         _.argument
           .order(2)
           .code("a")
-      ).head.code
-    match {
+      )
+      .head
+      .code match {
       case x =>
         x shouldBe "MOV dword ptr [RBP + -0x4],0xa"
       case _ => fail()
@@ -62,7 +63,8 @@ class CallNodeTests extends GhidraBinToCpgSuite {
       .name("level2")
       .caller
       .caller
-      .l.head
+      .l
+      .head
     x match {
       case x =>
         x.name shouldBe "main"
@@ -75,7 +77,8 @@ class CallNodeTests extends GhidraBinToCpgSuite {
     cpg.method
       .name("level2")
       .caller
-      .l.head match {
+      .l
+      .head match {
       case x =>
         x.name shouldBe "level1"
       case _ => fail()

--- a/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -315,13 +315,11 @@ class FunctionPass(
       handleArguments(instructions.head, prevInstructionNode)
       diffGraph.addEdge(blockNode, prevInstructionNode, EdgeTypes.AST)
       diffGraph.addEdge(methodNode.get, prevInstructionNode, EdgeTypes.CFG)
-      diffGraph.addEdge(methodNode.get, prevInstructionNode, EdgeTypes.CONTAINS)
       instructions.drop(1).foreach { instruction =>
         val instructionNode = addCallNode(instruction)
         diffGraph.addNode(instructionNode)
         handleArguments(instruction, instructionNode)
         diffGraph.addEdge(blockNode, instructionNode, EdgeTypes.AST)
-        diffGraph.addEdge(methodNode.get, instructionNode, EdgeTypes.CONTAINS)
         // Not connecting previous instruction if it is an unconditional jump
         // TODO: this needs to be adjusted to other architectures
         if (!prevInstructionNode.code.startsWith("JMP")) {

--- a/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/JumpPass.scala
+++ b/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/JumpPass.scala
@@ -7,15 +7,15 @@ import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
 class JumpPass(cpg: Cpg, keyPool: IntervalKeyPool)
-  extends ParallelCpgPass[Method](
-    cpg,
-    keyPools = Some(keyPool.split(1))
-  ) {
+    extends ParallelCpgPass[Method](
+      cpg,
+      keyPools = Some(keyPool.split(1))
+    ) {
 
   override def partIterator: Iterator[Method] = cpg.method.l.iterator
 
   override def runOnPart(method: Method): Iterator[DiffGraph] = {
-  implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
+    implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
     method.call
       .nameExact("<operator>.goto")
       .where(_.argument.order(1).isLiteral)


### PR DESCRIPTION
... `codepropertygraph` does this, the version was just not bumped in joern.